### PR TITLE
Fix WeakReference

### DIFF
--- a/jre/java/java/lang/ref/WeakReference.java
+++ b/jre/java/java/lang/ref/WeakReference.java
@@ -21,7 +21,7 @@ public class WeakReference<T> {
   }
 
   public T get() {
-    return referent.deref();
+    return referent != null ? referent.deref() : null;
   }
 
   public void clear() {


### PR DESCRIPTION
Fix WeakReference

- referent can be null (if .clear() is called), so it needs to be
  checked so things like WeakObservers don't attempt to fire if they've
  already been cleaned up.